### PR TITLE
カート機能のカート内が空だとボタンを表示しない

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -2,7 +2,7 @@ class Public::CartItemsController < ApplicationController
   before_action :authenticate_customer!
 
   def index
-    @cart_items = current_customer.cart_items.all
+    @cart_items = current_customer.cart_items
   end
 
   def create
@@ -40,10 +40,9 @@ class Public::CartItemsController < ApplicationController
   end
 
   def destroy_all #カート内全て削除
-    @cart_items = current_customer.cart_items.all
     cart_items = CartItem.all
     cart_items.destroy_all
-    render 'index'
+    redirect_to cart_items_path
   end
 
   private

--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -9,7 +9,7 @@ class Public::CartItemsController < ApplicationController
     @cart_item = current_customer.cart_items.new(cart_item_params)
         #もし元々カート内に「同じ商品」がある場合、「数量を追加」更新・保存する
     if current_customer.cart_items.find_by(item_id: params[:cart_item][:item_id]).present?
-                                      #元々カート内にあるもの「item_id」　
+                                      #元々カート内にあるもの「item_id」
                                       #今追加した　　　　　　　params[:cart_item][:item_id])
       cart_item = current_customer.cart_items.find_by(item_id: params[:cart_item][:item_id])
       cart_item.amount += params[:cart_item][:amount].to_i
@@ -17,7 +17,7 @@ class Public::CartItemsController < ApplicationController
                                                     #.to_iとして数字として扱う
       cart_item.save
       redirect_to cart_items_path
-    # もしカート内に「同じ」商品がない場合は通常の保存処理 
+    # もしカート内に「同じ」商品がない場合は通常の保存処理
     elsif @cart_item.save
         @cart_items = current_customer.cart_items.all
         render 'index'
@@ -40,6 +40,7 @@ class Public::CartItemsController < ApplicationController
   end
 
   def destroy_all #カート内全て削除
+    @cart_items = current_customer.cart_items.all
     cart_items = CartItem.all
     cart_items.destroy_all
     render 'index'

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -71,7 +71,11 @@
   </div>
 
   <div class=text-center>
-    <%= link_to '情報入力に進む', new_order_path, class: "btn btn-outline-dark ml-2 mt-3 mb-3", style:"margin-right:20px;" %>
+    <% if @cart_items.count != 0 %>
+      <%= link_to '情報入力に進む', new_order_path, class: "btn btn-outline-dark ml-2 mt-3 mb-3", style:"margin-right:20px;" %>
+    <% else %>
+      <div></div>
+    <% end %>
   </div>
 
 </main>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -28,7 +28,7 @@
         <div style="margin-left: 50px;">
           <%= f.radio_button :address_number, 2 %>
           <%= f.label :address_number, "登録先の住所から選択" %>
-          <%= f.collection_select :registered, current_customer.addresses.all, :id, :address_name_display,include_blank: '選択してください'  %>
+          <%= f.collection_select :registered, current_customer.addresses.all, :id, :address_name_display, include_blank: '選択してください'  %>
         </div>
       
         <div style="margin-left: 50px;">


### PR DESCRIPTION
カートが空→情報入力画面へ行くボタン表示しない
カートにものがある→ボタンを表示する。

renderをredirect_toに変更しました。