### PR TITLE
[add]レイアウト

### DIFF
--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -3,6 +3,7 @@ class Public::ItemsController < ApplicationController
 
   def index
     @items = Item.page(params[:page]).per(8)
+    @total_items = Item.count
   end
 
   def show

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h3 style="margin-bottom: 50px; margin-top: 50px;">商品一覧(全<%= @items.count =%>件)</h3>
+  <h3 style="margin-bottom: 50px; margin-top: 50px;">商品一覧(全<%= @total_items %>件)</h3>
   <div class="row">
 
 

--- a/app/views/public/orders/comfirm.html.erb
+++ b/app/views/public/orders/comfirm.html.erb
@@ -2,7 +2,7 @@
   <div class='container'>
     <div class='row'>
       <div class='col-8 mr-0'>
-      
+
         <table class="table table-bordered border-dark">
           <tr class="table-secondary" >
             <th>商品名</th>
@@ -10,7 +10,7 @@
             <th>数量</th>
             <th>小計</th>
           </tr>
-            
+
           <% @cart_items.each do |cart_item|%>
             <tr>
               <td><%= image_tag cart_item.item.get_image, size: "60x50" %>
@@ -29,12 +29,12 @@
             <td class="table-secondary" >送料</td>
             <td>800</td>
           </tr>
-          
+
           <tr>
             <td class="table-secondary" >商品合計</td>
             <td><%= @total.to_s(:delimited) %></td>
           </tr>
-          
+
           <tr>
             <td class="table-secondary" >請求金額</td>
             <td><%= @request_amount.to_s(:delimited) %></td>
@@ -43,7 +43,7 @@
       </div>
     </div>
   </div>
-  
+
   <div class='container'>
     <div class='row'>
       <div class='col-10 my-5'>
@@ -52,7 +52,7 @@
             <td><h5><strong>支払方法</strong></h5></td>
             <td><%= @order.payment_method_i18n %></td>
           </tr>
-          
+
           <tr>
             <td class="mt-0"><h5><strong>お届け先</strong></h5></td>
             <td>〒<%= @order.postal_code %><%= @order.address %><br>
@@ -63,7 +63,7 @@
       </div>
     </div>
   </div>
-  
+
   <%= form_with model:@order, url: orders_path, method: :post do |f|%>
     <%= f.hidden_field :name, :value => @order.name %>
     <%= f.hidden_field :address, :value => @order.address %>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -19,13 +19,13 @@
           <tr>
             <td><%= order.created_at.strftime('%Y/%m/%d') %></td>
             <td class="flex-{breakpoint}-column">
-                〒<%= order.postal_code %>
-                <%= order.address %>
-                <%= order.name %>
+                〒<%= order.postal_code %><br>
+                <%= order.address %><br>
+                <%= order.name %><br>
             </td>
             <td>
               <% order.order_details.each do |order_detail| %>
-                <%= order_detail.item.name %>
+                <%= order_detail.item.name %><br>
               <% end %>
             </td>
             <td>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -1,20 +1,20 @@
-  <div class='container'>
-    <div class=''>
-      <h4 class="ml-5 mt-3", style="background-color: #eee; width:170px; padding-left: 12px; margin-bottom:40px;" ><b>注文履歴詳細</b></h4>
+<div class="container auto">
+  <h4 class = "ml-5 mt-3" style = "background-color:#eee; width:170px; padding-left: 12px; margin-bottom:40px;"><b>注文履歴詳細</b></h4>
+    <div class='row'>
+      <div class='col-8 mr-0'>
 
-      <div class='col-md-6'>
         <h6><b>注文情報</b></h6>
         <table class="table table-bordered", style="margin:20px;">
           <tr>
-            <td style="background-color: #f5f5f5">注文日</td>
+            <td style="width:160px; background-color: #f5f5f5">注文日</td>
             <td><%= @order.created_at.strftime('%Y/%m/%d') %></td>
           </tr>
           <tr>
             <td style="background-color: #f5f5f5">配送先</td>
             <td>
-              〒<%= @order.postal_code %>
-              <%= @order.address %>
-              <%= @order.name %>
+              〒<%= @order.postal_code %><br>
+              <%= @order.address %><br>
+              <%= @order.name %><br>
             </td>
           </tr>
           <tr>
@@ -28,11 +28,11 @@
         </table>
       </div>
 
-      <div class='col-md-4'>
+      <div class='col-3'>
         <h6><b>請求情報</b></h6>
         <table class="table table-bordered", style="margin:20px;">
           <tr>
-            <td style="background-color: #f5f5f5">商品合計</td>
+            <td style="width:140px; background-color: #f5f5f5">商品合計</td>
             <td><%= (@order.total_payment - @order.shipping_cost) %></td>
           </tr>
           <tr>
@@ -46,14 +46,14 @@
         </table>
       </div>
 
-      <div class='col-md-8'>
+      <div class='col-md-9'>
         <h6><b>注文内容</b></h6>
         <table class="table table-bordered", style="margin:20px;">
           <tr>
-            <td style="background-color: #f5f5f5">商品</td>
-            <td style="background-color: #f5f5f5">単価（税込）</td>
+            <td style="width:450px; background-color: #f5f5f5">商品</td>
+            <td style="width:150px; background-color: #f5f5f5">単価（税込）</td>
             <td style="background-color: #f5f5f5">個数</td>
-            <td style="background-color: #f5f5f5">小計</td>
+            <td style="width:150px; background-color: #f5f5f5">小計</td>
           </tr>
 
           <% @order.order_details.each do |order_detail| %>


### PR DESCRIPTION
会員側の注文履歴詳細のレイアウトと商品一覧の"全〇件"のところがページネーションを入れたことにより8品以上の商品になるとそのページの商品しかカウントしない（全8件になる）という不具合があったのでコントローラでトータルを定義し8品以上商品があってもきちんとカウントするように修正しました。
確認をお願いします。